### PR TITLE
Add capability to deal with more samples per second so that a wider bandwidth can be processed.

### DIFF
--- a/common/wave.c
+++ b/common/wave.c
@@ -114,11 +114,20 @@ int load_wav(float* signal, int* num_samples, int* sample_rate, const char* path
     // This check causes unnecessary failures when the input file is > 15 sec long. So what if it is?
     //    if (subChunk2Size / blockAlign > *num_samples)
     //        return -2;
+    //
+    int signal_buffer_size = *num_samples;
 
-    // Why take these from the file? if they're garbage, we'll segfault
-    // They're already set by the caller
-    //    *num_samples = subChunk2Size / blockAlign;
-    //    *sample_rate = sampleRate;
+    *num_samples = subChunk2Size / blockAlign;
+    *sample_rate = sampleRate;
+
+    if (!signal) {
+        fclose(f);
+        return 1;
+    }
+
+    if (signal_buffer_size < *num_samples) {
+        return -1;  // buffer not large enough
+    }
 
     // Init sample buffer to zero in case the read is short
     int16_t* raw_data = (int16_t*)calloc(*num_samples, blockAlign);

--- a/decode_ft8.c
+++ b/decode_ft8.c
@@ -306,12 +306,18 @@ int main(int argc, char** argv)
         return -1;
     }
 
-    int sample_rate = 12000;
-    int num_samples = 15 * sample_rate;
-    float signal[num_samples];
+    int sample_rate;
+    int num_samples;
 
-    int rc = load_wav(signal, &num_samples, &sample_rate, wav_path);
-    if (rc < 0)
+    int rc = load_wav(NULL, &num_samples, &sample_rate, wav_path);
+    if (rc != 1) {
+        return -1;
+    }
+
+    float *signal = calloc(sizeof(float), num_samples);
+
+    rc = load_wav(signal, &num_samples, &sample_rate, wav_path);
+    if (rc != 0)
     {
         return -1;
     }
@@ -322,7 +328,7 @@ int main(int argc, char** argv)
     monitor_t mon;
     monitor_config_t mon_cfg = {
         .f_min = 100,
-        .f_max = 3000,
+        .f_max = sample_rate / 4,
         .sample_rate = sample_rate,
         .time_osr = kTime_osr,
         .freq_osr = kFreq_osr,


### PR DESCRIPTION
This just processes the WAV file header and extracts the number of samples per second from it, and then uses that data to allocate the buffer. Finally it sets the frequency range to search to be a quarter of the number of samples per second.

I've tested up to 400k samples per second for a 100kHz bandwidth. The vast majority of the traffic is on the traditional 3kHz channel, but there is other stuff -- possibly related to DXpeditions.