### PR TITLE
Adds support for FFTW3 and improved time resolution of frames.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,13 @@
-CFLAGS = -O3 -ggdb3
-CPPFLAGS = -std=c11 -I.
-LDFLAGS = -latomic -lbsd -lm
+# Use -DUSE_KISS if you want the kiss fft library
+# By default, this builds both a decode_ft8 (using FFTW3) and decode_ft8_kiss (using the KISS library)
+# It is only the decode_ft8.c file that depends on the USE_KISS define.
 
-TARGETS = gen_ft8 decode_ft8 test
+CFLAGS = -O3 -ggdb3 -march=native -flto -ffast-math 
+CPPFLAGS = -std=c11 -I. $(shell pkg-config --cflags fftw3f)
+LDFLAGS = -latomic -lbsd -lm -flto $(shell pkg-config --libs fftw3f)
+LDFLAGS_KISS = -latomic -lbsd -lm -flto 
+
+TARGETS = gen_ft8 decode_ft8 test decode_ft8_kiss
 
 .PHONY: run_tests all clean
 
@@ -12,13 +17,19 @@ run_tests: test
 	@./test
 
 gen_ft8: gen_ft8.o ft8/constants.o ft8/text.o ft8/pack.o ft8/encode.o ft8/crc.o common/wave.o
-	$(CXX) -o $@ $^ $(LDFLAGS)
+	$(CC) -o $@ $^ $(LDFLAGS)
 
-test:  test.o ft8/pack.o ft8/encode.o ft8/crc.o ft8/text.o ft8/constants.o fft/kiss_fftr.o fft/kiss_fft.o
-	$(CXX) -o $@ $^ $(LDFLAGS)
+test:  test.o ft8/pack.o ft8/encode.o ft8/crc.o ft8/text.o ft8/constants.o
+	$(CC) -o $@ $^ $(LDFLAGS)
 
-decode_ft8: main.o decode_ft8.o fft/kiss_fftr.o fft/kiss_fft.o ft8/decode.o ft8/encode.o ft8/crc.o ft8/ldpc.o ft8/unpack.o ft8/text.o ft8/constants.o common/wave.o
-	$(CXX) -o $@ $^ $(LDFLAGS)
+decode_ft8: main.o decode_ft8.o ft8/decode.o ft8/encode.o ft8/crc.o ft8/ldpc.o ft8/unpack.o ft8/text.o ft8/constants.o common/wave.o
+	$(CC) -o $@ $^ $(LDFLAGS) 
+
+decode_ft8_kiss: main.o decode_ft8_kiss.o ft8/decode.o ft8/encode.o ft8/crc.o ft8/ldpc.o ft8/unpack.o ft8/text.o ft8/constants.o common/wave.o fft/kiss_fft.o fft/kiss_fftr.o
+	$(CC) -o $@ $^ $(LDFLAGS_KISS) 
+
+decode_ft8_kiss.o: decode_ft8.c
+	$(CC) -c -o $@ $(CFLAGS) $(CCFLAGS) -DUSE_KISS $^
 
 clean:
 	rm -f *.o *.a ft8/*.o common/*.o fft/*.o $(TARGETS)

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,9 @@
 CFLAGS = -O3 -ggdb3 -march=native -flto -ffast-math 
 CPPFLAGS = -std=c11 -I. $(shell pkg-config --cflags fftw3f)
 LDFLAGS = -latomic -lbsd -lm -flto $(shell pkg-config --libs fftw3f)
+LDFLAGS = -lm -flto $(shell pkg-config --libs fftw3f)
 LDFLAGS_KISS = -latomic -lbsd -lm -flto 
+LDFLAGS_KISS = -lm -flto 
 
 TARGETS = gen_ft8 decode_ft8 test decode_ft8_kiss
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ The encoding process is relatively light on resources, and an Arduino should be 
 
 The decoder is designed with memory and computing efficiency in mind, in order to be usable with a fast enough microcontroller. It is shown to be working on STM32F7 boards fast enough for real work, but the embedded application itself is beyond this repository. This repository provides an example decoder which can decode a 15-second WAV file on a desktop machine or SBC. The decoder needs to access the whole 15-second window in spectral magnitude representation (the window can be also shorter, and messages can have varying starting time within the window). The example FT8 decoder can work with slightly less than 200 KB of RAM. 
 
+If you have lots of RAM and a good CPU, then you can use the version with makes use of FFTW3. It is much faster than the version with FFT implementation from this repository. It is enabled by default in the Makefile.
+
+This version, by default, aligns the decode to the nearest 10ms of the detected frame. If you want the old, faster,
+behavior, then add `-T 2` to the `decode_ft8` command line. This provides slightly fewer decodes, and should give
+the same results as earlier versions of this code.
+
 # Current state
 
 Currently the basic message set for establishing QSOs, as well as telemetry and free-text message modes are supported:

--- a/decode_ft8.c
+++ b/decode_ft8.c
@@ -16,8 +16,12 @@
 
 #include "common/wave.h"
 #include "common/debug.h"
+#ifdef USE_KISS
 #include "fft/kiss_fftr.h"
 #include "fft/kiss_fft.h"
+#else
+#include <fftw3.h>
+#endif
 
 #define LOG_LEVEL LOG_FATAL
 
@@ -29,8 +33,32 @@ const int kLDPC_iterations = 20;
 // Making this bigger seems to only cost memory, which I now allocate from the heap, so what the hell
 const int kMax_decoded_messages = 1000;
 
-const int kFreq_osr = 2; // Frequency oversampling rate (bin subdivision)
-const int kTime_osr = 2; // Time oversampling rate (symbol subdivision)
+int kFreq_osr = 2; // Frequency oversampling rate (bin subdivision)
+int kTime_osr = 16; // Time oversampling rate (symbol subdivision)
+
+#ifndef USE_KISS
+static uint8_t log_lut[65536];
+static float db_lut[65536];
+static bool log_lut_initialized = false;
+
+static void log_lut_init(void) {
+  if (log_lut_initialized)
+    return;
+  for (int i = 0; i < 65536; ++i) {
+    union {
+      uint32_t u;
+      float f;
+    } v;
+    v.u = (uint32_t)i << 15;
+    float db = 10.0f * log10f(1E-12f + v.f);
+    int scaled = (int)(2 * db + 240);
+    log_lut[i] = (scaled < 0) ? 0 : ((scaled > 255) ? 255 : scaled);
+    db_lut[i] = db;
+  }
+  log_lut_initialized = true;
+}
+#endif
+
 static float hann_i(int i, int N)
 {
     float x = sinf((float)M_PI * i / N);
@@ -102,9 +130,16 @@ typedef struct
     waterfall_t wf;      ///< Waterfall object
     float max_mag;       ///< Maximum detected magnitude (debug stats)
 
+#ifdef USE_KISS
     // KISS FFT housekeeping variables
     void* fft_work;        ///< Work area required by Kiss FFT
     kiss_fftr_cfg fft_cfg; ///< Kiss FFT housekeeping object
+#else
+    // FFTW3 housekeeping variables
+    float *fft_in;          ///< Input buffer for FFTW
+    fftwf_complex *fft_out; ///< Output buffer for FFTW
+    fftwf_plan fft_plan;    ///< FFTW plan
+#endif
 } monitor_t;
 
 void monitor_init(monitor_t* me, const monitor_config_t* cfg)
@@ -129,16 +164,31 @@ void monitor_init(monitor_t* me, const monitor_config_t* cfg)
     }
     me->last_frame = (float *)malloc(me->nfft * sizeof(me->last_frame[0]));
 
+#ifdef USE_KISS
     size_t fft_work_size;
     kiss_fftr_alloc(me->nfft, 0, 0, &fft_work_size);
+#endif
 
     LOG(LOG_INFO, "Block size = %d\n", me->block_size);
     LOG(LOG_INFO, "Subblock size = %d\n", me->subblock_size);
     LOG(LOG_INFO, "N_FFT = %d\n", me->nfft);
+#ifdef USE_KISS
     LOG(LOG_DEBUG, "FFT work area = %zu\n", fft_work_size);
-
+ 
     me->fft_work = malloc(fft_work_size);
     me->fft_cfg = kiss_fftr_alloc(me->nfft, 0, me->fft_work, &fft_work_size);
+#else
+    me->fft_in = (float *)fftwf_malloc(sizeof(float) * me->nfft);
+    me->fft_out =
+        (fftwf_complex *)fftwf_malloc(sizeof(fftwf_complex) * (me->nfft / 2 + 1));
+  
+    fftwf_import_wisdom_from_filename(".ft8_fftw_wisdom");
+    me->fft_plan =
+        fftwf_plan_dft_r2c_1d(me->nfft, me->fft_in, me->fft_out, FFTW_MEASURE);
+    fftwf_export_wisdom_to_filename(".ft8_fftw_wisdom");
+
+    log_lut_init();
+#endif
 
     const int max_blocks = (int)(slot_time / symbol_period);
     const int num_bins = (int)(cfg->sample_rate * symbol_period / 2);
@@ -152,7 +202,13 @@ void monitor_init(monitor_t* me, const monitor_config_t* cfg)
 void monitor_free(monitor_t* me)
 {
     waterfall_free(&me->wf);
+#ifdef USE_KISS
     free(me->fft_work);
+#else
+    fftwf_destroy_plan(me->fft_plan);
+    fftwf_free(me->fft_in);
+    fftwf_free(me->fft_out);
+#endif
     free(me->last_frame);
     free(me->window);
 }
@@ -170,9 +226,10 @@ void monitor_process(monitor_t* me, const float* frame)
     // Loop over block subdivisions
     for (int time_sub = 0; time_sub < me->wf.time_osr; ++time_sub)
     {
+#ifdef USE_KISS
         kiss_fft_scalar timedata[me->nfft];
         kiss_fft_cpx freqdata[me->nfft / 2 + 1];
-
+#endif
         // Shift the new data into analysis frame
         for (int pos = 0; pos < me->nfft - me->subblock_size; ++pos)
         {
@@ -185,12 +242,19 @@ void monitor_process(monitor_t* me, const float* frame)
         }
 
         // Compute windowed analysis frame
-        for (int pos = 0; pos < me->nfft; ++pos)
-        {
+        for (int pos = 0; pos < me->nfft; ++pos) {
+#ifdef USE_KISS
             timedata[pos] = me->fft_norm * me->window[pos] * me->last_frame[pos];
+#else
+            me->fft_in[pos] = me->fft_norm * me->window[pos] * me->last_frame[pos];
+#endif
         }
 
-        kiss_fftr(me->fft_cfg, timedata, freqdata);
+#ifdef USE_KISS
+	kiss_fftr(me->fft_cfg, timedata, freqdata);
+#else
+	fftwf_execute(me->fft_plan);
+#endif
 
         // Loop over two possible frequency bin offsets (for averaging)
         for (int freq_sub = 0; freq_sub < me->wf.freq_osr; ++freq_sub)
@@ -198,6 +262,7 @@ void monitor_process(monitor_t* me, const float* frame)
             for (int bin = 0; bin < me->wf.num_bins; ++bin)
             {
                 int src_bin = (bin * me->wf.freq_osr) + freq_sub;
+#ifdef USE_KISS
                 float mag2 = (freqdata[src_bin].i * freqdata[src_bin].i) + (freqdata[src_bin].r * freqdata[src_bin].r);
                 float db = 10.0f * log10f(1E-12f + mag2);
                 // Scale decibels to unsigned 8-bit range and clamp the value
@@ -205,8 +270,20 @@ void monitor_process(monitor_t* me, const float* frame)
                 int scaled = (int)(2 * db + 240);
 
                 me->wf.mag[offset] = (scaled < 0) ? 0 : ((scaled > 255) ? 255 : scaled);
-                ++offset;
-
+#else
+                union {
+                  float f;
+                  uint32_t u;
+                } v;
+                v.f = (me->fft_out[src_bin][1] * me->fft_out[src_bin][1]) +
+                      (me->fft_out[src_bin][0] * me->fft_out[src_bin][0]);
+        
+                uint32_t idx = (v.u >> 15) & 0xffff;
+                me->wf.mag[offset] = log_lut[idx];
+ 
+                float db = db_lut[idx];
+#endif
+	        ++offset;
                 if (db > me->max_mag)
                     me->max_mag = db;
             }
@@ -238,6 +315,19 @@ int mcompare(void const *a, void const *b){
   else if(ma->freq_hz < mb->freq_hz)
     return -1;
   return 0;
+}
+
+static char *hexify(char *buff, const uint8_t *bits, size_t len) {
+  char *obuff = buff;
+  while (len > 0) {
+    *buff++ = "0123456789abcdef"[bits[0] >> 4];
+    *buff++ = "0123456789abcdef"[bits[0] & 0x0f];
+    bits++;
+    len--;
+  }
+  *buff++ = '\0';
+
+  return obuff;
 }
 
 // Process a buffer already loaded from a file
@@ -272,6 +362,7 @@ int process_buffer(float const *signal,int sample_rate, int num_samples, bool is
   int const candidate_size = (mon_cfg.f_max * kMax_candidates) / 3000; // Scale by bandwidth relative to the original 3 kHz
   candidate_t candidate_list[candidate_size];
   int num_candidates = ft8_find_sync(&mon.wf, candidate_size, candidate_list, kMin_score);
+  LOG(LOG_DEBUG, "Candidates = %d (of %d)\n", num_candidates, candidate_size);
 
   // Hash table for decoded messages (to check for duplicates)
   int num_decoded = 0;
@@ -357,20 +448,23 @@ int process_buffer(float const *signal,int sample_rate, int num_samples, bool is
 
   for(int i=0; i < num_decoded; i++){
     message_t const *mp = decoded_hashtable[i];
+    char hexbuffer[sizeof(mp->bits) * 2 + 1];
     if(mp == NULL)
       continue; // Shouldn't happen
 
-    fprintf(stdout,"%4d/%02d/%02d %02d:%02d:%02d %3d %+4.2lf %'.1lf ~ %s\n",
-	    tmp->tm_year + 1900,
-	    tmp->tm_mon + 1,
-	    tmp->tm_mday,
+    fprintf(stdout,
+            "%4d/%02d/%02d %02d:%02d:%02d %3d %+4.2lf %'.1lf ~ %s  #%s\n",
+            tmp->tm_year + 1900, 
+	    tmp->tm_mon + 1, 
+	    tmp->tm_mday, 
 	    tmp->tm_hour,
-	    tmp->tm_min,
-	    tmp->tm_sec,
-	    mp->score,
+            tmp->tm_min, 
+	    tmp->tm_sec, 
+	    mp->score, 
 	    tbase + mp->time_sec,
-	    1.0e6 * base_freq + mp->freq_hz,
-	    mp->text);
+            1.0e6 * base_freq + mp->freq_hz, 
+	    mp->text,
+            hexify(hexbuffer, mp->bits, sizeof(mp->bits)));
   }
   free(decoded);
   free(decoded_hashtable);

--- a/decode_ft8.c
+++ b/decode_ft8.c
@@ -443,7 +443,7 @@ int process_buffer(float const *signal,int sample_rate, int num_samples, bool is
   qsort(decoded_hashtable, kMax_decoded_messages, sizeof *decoded_hashtable, mcompare);
   // Empty entries sorted to top, so first num_decoded elements of decoded_hashtable are valid
   double tbase = tmp->tm_sec; // Full seconds and fraction in minute, should be just above (not below) period multiple
-  tbase = is_ft8 ? fmod(tbase,15.0) : fmod(tbase,7.5); // seconds after start of cycle (0/15/30/45 or 0/7.5/15/etc)
+  tbase = is_ft8 ? fmod(tbase,15.0) : fmod(tbase+1,7.5)-1; // seconds after start of cycle (0/15/30/45 or 0/7.5/15/etc)
   tbase += sec; // sec could be negative, so add it only now
 
   for(int i=0; i < num_decoded; i++){

--- a/ft8/decode.c
+++ b/ft8/decode.c
@@ -6,6 +6,7 @@
 
 #include <stdbool.h>
 #include <math.h>
+#include <string.h>
 
 /// Compute log likelihood log(p(1) / p(0)) of 174 message bits for later use in soft-decision LDPC decoding
 /// @param[in] wf Waterfall data collected during message slot
@@ -41,9 +42,9 @@ static int get_index(const waterfall_t* wf, const candidate_t* candidate)
     return offset;
 }
 
-static int ft8_sync_score(const waterfall_t* wf, const candidate_t* candidate)
+static float ft8_sync_score(const waterfall_t* wf, const candidate_t* candidate)
 {
-    int score = 0;
+    float score = 0;
     int num_average = 0;
 
     // Get the pointer to symbol 0 of the candidate
@@ -107,9 +108,9 @@ static int ft8_sync_score(const waterfall_t* wf, const candidate_t* candidate)
     return score;
 }
 
-static int ft4_sync_score(const waterfall_t* wf, const candidate_t* candidate)
+static float ft4_sync_score(const waterfall_t* wf, const candidate_t* candidate)
 {
-    int score = 0;
+    float score = 0;
     int num_average = 0;
 
     // Get the pointer to symbol 0 of the candidate
@@ -175,48 +176,91 @@ int ft8_find_sync(const waterfall_t* wf, int num_candidates, candidate_t heap[],
     int heap_size = 0;
     candidate_t candidate;
 
-    // Here we allow time offsets that exceed signal boundaries, as long as we still have all data bits.
-    // I.e. we can afford to skip the first 7 or the last 7 Costas symbols, as long as we track how many
-    // sync symbols we included in the score, so the score is averaged.
-    for (candidate.time_sub = 0; candidate.time_sub < wf->time_osr; ++candidate.time_sub)
-    {
-        for (candidate.freq_sub = 0; candidate.freq_sub < wf->freq_osr; ++candidate.freq_sub)
-        {
-            for (candidate.time_offset = -12; candidate.time_offset < 24; ++candidate.time_offset)
-            {
-                for (candidate.freq_offset = 0; (candidate.freq_offset + 7) < wf->num_bins; ++candidate.freq_offset)
-                {
-                    if (wf->protocol == PROTO_FT4)
-                    {
-                        candidate.score = ft4_sync_score(wf, &candidate);
-                    }
-                    else
-                    {
-                        candidate.score = ft8_sync_score(wf, &candidate);
-                    }
-
-                    if (candidate.score < min_score)
-                        continue;
-
-                    // If the heap is full AND the current candidate is better than
-                    // the worst in the heap, we remove the worst and make space
-                    if (heap_size == num_candidates && candidate.score > heap[0].score)
-                    {
-                        heap[0] = heap[heap_size - 1];
-                        --heap_size;
-                        heapify_down(heap, heap_size);
-                    }
-
-                    // If there's free space in the heap, we add the current candidate
-                    if (heap_size < num_candidates)
-                    {
-                        heap[heap_size] = candidate;
-                        ++heap_size;
-                        heapify_up(heap, heap_size);
-                    }
-                }
+    int time_size = wf->time_osr * (24 + 12);
+    int freq_size = wf->freq_osr * (wf->num_bins - 7);
+    float max_score = 1;
+  
+    // Here we allow time offsets that exceed signal boundaries, as long as we
+    // still have all data bits. I.e. we can afford to skip the first 7 or the
+    // last 7 Costas symbols, as long as we track how many sync symbols we
+    // included in the score, so the score is averaged.
+  
+    // We want to find the best time offset in each sliding 0.5 second window, and
+    // then add it as a candidate if it's better than the worst in the heap.
+    const int half_time_osr = (wf->time_osr + 1) / 2;
+  
+    for (candidate.freq_offset = 0;
+            (candidate.freq_offset + 7) < wf->num_bins;
+            ++candidate.freq_offset) {
+      for (candidate.freq_sub = 0; candidate.freq_sub < wf->freq_osr; ++candidate.freq_sub) {
+        // we ignore the first and last symbols so that we don't have to worry about
+        // going over the bounds in the search below.
+        for (candidate.time_offset = -11; candidate.time_offset < 23;
+            ++candidate.time_offset) {
+          // We go around this loop twice to see if there is any hope of a transmission
+          for (candidate.time_sub = 0; candidate.time_sub < wf->time_osr;
+              candidate.time_sub += half_time_osr) {
+  
+            float candidate_score;
+            if (wf->protocol == PROTO_FT4) {
+              candidate_score = ft4_sync_score(wf, &candidate);
+            } else {
+              candidate_score = ft8_sync_score(wf, &candidate);
             }
+  
+            candidate.score = (int)candidate_score;
+
+	    if (candidate.score < min_score)
+		continue;
+
+            if (candidate_score - min_score > max_score)
+              max_score = candidate_score - min_score;
+  
+            // We now have a potential candidate which passes the bar. Now we 
+            // search for the best candidate within one symbol period backwards and
+            // forwards in time. The code is slightly nastier since the candidate time_sub
+            // field is unsigned.
+            candidate_t search_candidate = candidate;
+            candidate_t best_candidate = candidate;
+            search_candidate.time_offset--;
+            search_candidate.time_sub += 1;
+            for (int time_osr_offset = -wf->time_osr; 
+                 time_osr_offset < wf->time_osr; 
+                 ++time_osr_offset, ++search_candidate.time_sub) {
+              if (wf->protocol == PROTO_FT4) {
+                candidate_score = ft4_sync_score(wf, &search_candidate);
+              } else {
+                candidate_score = ft8_sync_score(wf, &search_candidate);
+              }
+  
+              if (candidate_score - min_score > max_score)
+                max_score = candidate_score - min_score;
+  
+              search_candidate.score = (int)candidate_score;
+              if (candidate_score > best_candidate.score) {
+                best_candidate = search_candidate;
+              }
+            }
+  
+	    // If the heap is full AND the current candidate is better than
+	    // the worst in the heap, we remove the worst and make space
+            if (heap_size == num_candidates && best_candidate.score > heap[0].score) {
+              heap[0] = heap[heap_size - 1];
+              --heap_size;
+              heapify_down(heap, heap_size);
+            }
+ 
+            // If there's free space in the heap, we add the current candidate
+            if (heap_size < num_candidates) {
+              heap[heap_size] = best_candidate;
+              ++heap_size;
+              heapify_up(heap, heap_size);
+            }
+            candidate.time_offset += 2;  // Skip the next 2 time offsets, so we don't get duplicates
+            break;  // Dealt with this offset.
+          }
         }
+      }
     }
 
     // Sort the candidates by sync strength - here we benefit from the heap structure
@@ -362,6 +406,7 @@ bool ft8_decode(const waterfall_t* wf, const candidate_t* cand, message_t* messa
         }
     }
 
+    memcpy(message->bits, a91, sizeof(message->bits));
     status->unpack_status = unpack77(a91, message->text);
 
     if (status->unpack_status < 0)

--- a/ft8/decode.h
+++ b/ft8/decode.h
@@ -46,6 +46,7 @@ extern "C"
         // TODO: check again that this size is enough
         char text[25]; ///< Plain text
         uint16_t hash; ///< Hash value to be used in hash table and quick checking for duplicates
+        uint8_t bits[10];   ///< The 77 bits of the message
       // Store so we can display them after sorting
       float freq_hz;   // We will sort on this
       float time_sec;

--- a/main.c
+++ b/main.c
@@ -44,6 +44,8 @@
   #define st_ctim st_ctimespec
 #endif
 
+extern int kTime_osr;
+extern int kFreq_osr;
 
 int Verbose = 0;
 bool NoDelete; // Don't delete input file after decoding
@@ -66,6 +68,7 @@ void usage();
 int main(int argc, char *argv[]){
   const char* path = NULL;
   bool is_ft8 = true;
+  kTime_osr = 16;
 
   // Base freq; if not specified with -f in megahertz, extracted from input filename of form
   // yyyymmddThhmmssZ_ffffffff_usb.wav
@@ -74,8 +77,8 @@ int main(int argc, char *argv[]){
   // ffffffffff is frequency in *hertz*
   double base_freq = 0;
   int c;
-  while((c = getopt(argc,argv,"48f:vnr")) != -1){
-    switch(c){
+  while ((c = getopt(argc, argv, "48f:vnrT:F:")) != -1) {
+    switch (c) {
     case 'r':
       Run_queue = true;
       break;
@@ -87,12 +90,20 @@ int main(int argc, char *argv[]){
       break;
     case '8':
       is_ft8 = true; // In case it's not the default
+      kTime_osr = 16;
       break;
     case '4': // Decode FT4; default is FT8
       is_ft8 = false;
+      kTime_osr = 5;
       break;
     case 'f': // Base frequency in Megahertz, otherwise extracted from file name
-      base_freq = strtod(optarg,NULL);
+      base_freq = strtod(optarg, NULL);
+      break;
+    case 'F':
+      kFreq_osr = atoi(optarg);
+      break;
+    case 'T':
+      kTime_osr = atoi(optarg);
       break;
     }
   }
@@ -522,6 +533,8 @@ int process_file(char const * const path, bool is_ft8, double base_freq){
 	fprintf(stderr,"can't delete %s: %s\n",lockfile,strerror(errno));
       }
     }
+    free(signal); // Must free the signal buffer
+    // signal = NULL;
     return -1;
   }
   if(base_freq == 0){
@@ -759,8 +772,7 @@ done:;
     close(dir_fd); // otherwise close it separately
 }
 
-
-void usage()
-{
-  fprintf(stderr, "decode_ft8 [-v] [-8|-4] [-d] [-f basefreq] file_or_directory\n");
+void usage() {
+  fprintf(stderr, "decode_ft8 [-F sub] [-T sub] [-v] [-8|-4] [-d] [-r] [-f "
+                  "basefreq] file_or_directory\n");
 }

--- a/main.c
+++ b/main.c
@@ -304,7 +304,6 @@ int main(int argc, char *argv[]){
 #endif
   exit(0);
 }
-#ifdef __linux__
 int scompare(void const *a, void const *b){
   char const *ap = *(char const **)a;
   char const *bp = *(char const **)b;
@@ -315,6 +314,7 @@ int scompare(void const *a, void const *b){
     return +1;
   return strcmp(ap,bp);
 }
+#ifdef __linux__
 
 // Add a directory to the watch list
 int Watches = 0;

--- a/test.c
+++ b/test.c
@@ -9,9 +9,9 @@
 #include "ft8/encode.h"
 #include "ft8/constants.h"
 
-#include "fft/kiss_fftr.h"
 #include "common/common.h"
 #include "common/debug.h"
+#include <fftw3.h>
 
 #define LOG_LEVEL LOG_INFO
 
@@ -115,39 +115,35 @@ void test_tones(float* log174)
     }
 }
 
-void test4()
-{
-    const int nfft = 128;
-    const float fft_norm = 2.0 / nfft;
+void test4() {
+  const int nfft = 128;
+  const float fft_norm = 2.0 / nfft;
 
-    size_t fft_work_size;
-    kiss_fftr_alloc(nfft, 0, 0, &fft_work_size);
+  fftwf_plan fft_plan;
+  float *fft_in = (float *)fftwf_malloc(sizeof(float) * nfft);
+  fftwf_complex *fft_out =
+      (fftwf_complex *)fftwf_malloc(sizeof(fftwf_complex) * (nfft / 2 + 1));
+  fft_plan = fftwf_plan_dft_r2c_1d(nfft, fft_in, fft_out, FFTW_ESTIMATE);
 
-    printf("N_FFT = %d\n", nfft);
-    printf("FFT work area = %lu\n", fft_work_size);
+  for (int i = 0; i < nfft; ++i) {
+    fft_in[i] = sinf(i * 2 * (float)M_PI / nfft);
+  }
 
-    void* fft_work = malloc(fft_work_size);
-    kiss_fftr_cfg fft_cfg = kiss_fftr_alloc(nfft, 0, fft_work, &fft_work_size);
+  fftwf_execute(fft_plan);
 
-    kiss_fft_scalar window[nfft];
-    for (int i = 0; i < nfft; ++i)
-    {
-        window[i] = sinf(i * 2 * (float)M_PI / nfft);
-    }
+  float mag_db[nfft];
+  // Compute log magnitude in decibels
+  for (int j = 0; j < nfft / 2 + 1; ++j) {
+    float mag2 =
+        (fft_out[j][0] * fft_out[j][0] + fft_out[j][1] * fft_out[j][1]);
+    mag_db[j] = 10.0f * log10f(1E-10f + mag2 * fft_norm * fft_norm);
+  }
+  fftwf_destroy_plan(fft_plan);
+  fftwf_free(fft_in);
+  fftwf_free(fft_out);
 
-    kiss_fft_cpx freqdata[nfft / 2 + 1];
-    kiss_fftr(fft_cfg, window, freqdata);
-
-    float mag_db[nfft];
-    // Compute log magnitude in decibels
-    for (int j = 0; j < nfft / 2 + 1; ++j)
-    {
-        float mag2 = (freqdata[j].i * freqdata[j].i + freqdata[j].r * freqdata[j].r);
-        mag_db[j] = 10.0f * log10f(1E-10f + mag2 * fft_norm * fft_norm);
-    }
-
-    printf("F[0] = %.1f dB\n", mag_db[0]);
-    printf("F[1] = %.3f dB\n", mag_db[1]);
+  printf("F[0] = %.1f dB\n", mag_db[0]);
+  printf("F[1] = %.3f dB\n", mag_db[1]);
 }
 
 int main()


### PR DESCRIPTION
This does a number of things:

- Uses fftw3 instead of kiss by default. This is to improve CPU performance
- Uses a log10 approximation. This improves CPU performance
- Sets kTime_osr to a value such that we get output timestamps to 10ms precision. Uses optimised search process not to create lots of candidates.
- Adds the decoded hex packet to the end of the log line
- Adds compiler options (-march=native) to make it compile better on specific chipsets

The result of this is reduced CPU consumption (around halved apples-to-apples). However, since this version defaults to oversampling in time by 16 or 5 (ft8, ft4) rather than 2, it actually does a lot more work and ends up using about the same amount of CPU. It also generates maybe 5% more decodes as it aligns the ft4/8 packet better (in time).

The `Makefile` builds both versions of the decode_ft8 -- one using FFTW3 and one using KISS.